### PR TITLE
Fixing crashing on directories that contain a dicom that is unreadable. Still, includes rows for unreadable files.

### DIFF
--- a/dcmpandas.py
+++ b/dcmpandas.py
@@ -170,7 +170,7 @@ def scrape(directory = '.',
     df = pd.merge(df, pd.DataFrame(fail_path,  columns=['Filename']), how="outer")
     df['ReadError'] = read_error
 
-    Save to disk
+    # Save to disk
     if database_file is not None:
         pickle.dump([tags, df],open(database_file,'wb'))
     else:

--- a/dcmpandas.py
+++ b/dcmpandas.py
@@ -57,7 +57,7 @@ series.
 import os
 import sys
 import glob
-import pydicom as dicom
+import dicom
 import pandas
 import pickle
 import fnmatch

--- a/dcmpandas.py
+++ b/dcmpandas.py
@@ -176,28 +176,5 @@ def scrape(directory = '.',
     else:
         return tags,df
 
-    
-def load(database_file='dicom.pickle'):
-    '''Load a database file from the disk'''
-    return pd.read_pickle(database_file)
-
-def load_image(filename):
-    '''Load an image into a series'''
-    tags,df = scrape(database_file = None,
-                     glob_pattern = filename,
-                     verbose=0)
-    return df.iloc[0]
-    
-def load(database_file='dicom.pickle'):
-    '''Load a database file from the disk'''
-    return pandas.read_pickle(database_file)
-
-def load_image(filename):
-    '''Load an image into a series'''
-    tags,df = scrape(database_file = None,
-                     glob_pattern = filename,
-                     verbose=0)
-    return df.iloc[0]
-
 if __name__=='__main__':
     pass

--- a/dcmpandas.py
+++ b/dcmpandas.py
@@ -58,7 +58,7 @@ import os
 import sys
 import glob
 import dicom
-import pandas
+import pandas as pd
 import pickle
 import fnmatch
 


### PR DESCRIPTION
If there was a subdir with say 10 dicoms, and one was unreadable due to bad data in the header, `scrape` would stop parsing that directory when it encountered the problematic file. Worst case scenario, you could miss all good 9 dicoms because of the presence of the 1 bad one. Further, you don't have any information on which file was corrupted in your final output.

Here's some proposed changes, whereas:  

If verbose, the function will print the talkback  
`failed: <path>` when it encounters failed parsing attempts

More importantly, the scrape will continue, and for the bad file, information will be preserved in 2 ways:  
* the final dataframe that the function creates will contain a row that contains only NaN values, except for the column that contains the path (look at `df['Filename']` below)  
* the final dataframe will contain a new indicator column with a 0 or 1 to denote if the dicom was parsed successfully  (look at `df[ReadError]` below)

Here's an example of the final dataframe in the event that the function comes across an unreadable file:  

<img width="982" alt="screen shot 2017-12-22 at 4 26 14 pm" src="https://user-images.githubusercontent.com/6037050/34315502-4b9b518a-e735-11e7-8aeb-992510b8e734.png">

(hummm...maybe next, I can change the `df[ReadError]` to actually contain the error text when it gets generated)
